### PR TITLE
Fix/logging level

### DIFF
--- a/src/main/java/uk/gov/ons/sbr/data/hbase/load/BulkLoader.java
+++ b/src/main/java/uk/gov/ons/sbr/data/hbase/load/BulkLoader.java
@@ -131,13 +131,14 @@ public class BulkLoader extends Configured implements Tool {
 
                             // Auto configure partitioner and reducer
                             HFileOutputFormat2.configureIncrementalLoad(job, table, regionLocator);
-                            FileOutputFormat.setOutputPath(job, new Path(String.format("%s%s%s_%s_%d", outputFilePath, Path.SEPARATOR, unitType.toString(), referencePeriod, start.getEpochSecond())));
+                            Path hfilePath = new Path(String.format("%s%s%s_%s_%d", outputFilePath, Path.SEPARATOR, unitType.toString(), referencePeriod, start.getEpochSecond()));
+                            FileOutputFormat.setOutputPath(job, hfilePath);
 
                             if (job.waitForCompletion(true)) {
                                 try (Admin admin = connection.getAdmin()) {
                                     // Load generated HFiles into table
                                     LoadIncrementalHFiles loader = new LoadIncrementalHFiles(conf);
-                                    loader.doBulkLoad(new Path(outputFilePath), admin, table, regionLocator);
+                                    loader.doBulkLoad(hfilePath, admin, table, regionLocator);
                                 }
                             } else {
                                 LOG.error("Loading of data failed.");

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,12 +9,12 @@
         </encoder>
     </appender>
 
-    <logger name="uk.gov.ons" level="FINE"
+    <logger name="uk.gov.ons" level="INFO"
             additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 
-    <root level="DEBUG">
+    <root level="WARN">
         <appender-ref ref="STDOUT" />
     </root>
 


### PR DESCRIPTION
Reduced logging level to INFO/WARN 

- Switched off TRACE logging for uk.gov.ons packages
- Set default logging level to INFO/WARN